### PR TITLE
Include source generator in NuGet package

### DIFF
--- a/src/TONL.NET.Core/TONL.NET.Core.csproj
+++ b/src/TONL.NET.Core/TONL.NET.Core.csproj
@@ -39,6 +39,15 @@
   <ItemGroup>
     <ProjectReference Include="..\TONL.NET.SourceGenerator\TONL.NET.SourceGenerator.csproj"
                       OutputItemType="Analyzer"
-                      ReferenceOutputAssembly="false" />
+                      ReferenceOutputAssembly="false"
+                      PrivateAssets="all" />
+  </ItemGroup>
+
+  <!-- Include source generator in NuGet package -->
+  <ItemGroup>
+    <None Include="..\TONL.NET.SourceGenerator\bin\$(Configuration)\netstandard2.0\TONL.NET.SourceGenerator.dll"
+          Pack="true"
+          PackagePath="analyzers/dotnet/cs"
+          Visible="false" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
Fix NuGet package to include the source generator DLL.

## Problem
The `ProjectReference` with `OutputItemType="Analyzer"` only works for local development - it doesn't package the analyzer DLL into the NuGet package.

## Solution
Add the source generator DLL to `analyzers/dotnet/cs` in the package:

```xml
<None Include="..\TONL.NET.SourceGenerator\bin\$(Configuration)\netstandard2.0\TONL.NET.SourceGenerator.dll"
      Pack="true"
      PackagePath="analyzers/dotnet/cs"
      Visible="false" />
```

## Package contents now
```
lib/net9.0/TONL.NET.Core.dll      # Runtime library
lib/net10.0/TONL.NET.Core.dll     # Runtime library  
analyzers/dotnet/cs/TONL.NET.SourceGenerator.dll  # Source generator
```

## Test plan
- [x] `dotnet pack` produces correct package structure
- [ ] Verify source generator works when installed from NuGet