### PR TITLE
[#23] 1.2.0: TonlElement + WriteRawValue + WriteUInt64

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to TONL.NET will be documented in this file.
 
+## [1.2.0] - 2026-05-20
+
+### Added
+
+- **`TonlElement`** — readonly struct wrapping pre-rendered TONL bytes. Use to embed dynamic-schema payloads inside source-gen-serialized envelopes (e.g., database result sets where the row schema is determined at runtime).
+- **`TonlWriter.WriteRawValue(ReadOnlySpan<byte>)`** + **`WriteKeyRawValue(ReadOnlySpan<char>, ReadOnlySpan<byte>)`** — public primitives for emitting pre-rendered TONL fragments. Caller is responsible for fragment validity.
+- **`TonlWriter.WriteUInt64(ulong)`** + **`WriteKeyUInt64(ReadOnlySpan<char>, ulong)`** — close the `ulong` API gap. Source generator now emits these for `ulong` properties instead of the previous `ToString()` fallback (which produced quoted strings for values > `long.MaxValue`).
+
+### Changed
+
+- Source generator now treats `TonlElement` as a leaf type during recursive type discovery — no recursion into its `Bytes` payload.
+- `ulong` properties now serialize as bare integers (was: quoted strings via `.ToString()`). Existing serialized output of `ulong` values changes from `"123"` to `123` — non-breaking for spec conformance, but consumers parsing old output as strings may need updating.
+
+### Tests
+
+- 377 tests (up from 360) covering `WriteRawValue`, `WriteKeyRawValue`, `WriteUInt64`, `WriteKeyUInt64`, `TonlElement` source-gen special-case, and `ulong` bare-integer codegen. AOT test count: 58 (up from 51).
+
 ## [1.1.0] - 2026-03-08
 
 ### Added

--- a/src/TONL.NET.Core/TonlElement.cs
+++ b/src/TONL.NET.Core/TonlElement.cs
@@ -1,0 +1,40 @@
+namespace TONL.NET;
+
+/// <summary>
+/// Opaque wrapper over pre-rendered TONL bytes. Use to embed a payload whose
+/// shape is determined at runtime (e.g., a dynamic-schema database result set)
+/// inside a source-gen-serialized envelope. The source generator special-cases
+/// this type to emit the bytes directly via WriteKeyRawValue.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <strong>Lifetime contract:</strong> <see cref="TonlElement"/> holds the bytes the caller hands it.
+/// If the caller passed <c>TonlBufferWriter.WrittenMemory</c> (pool-backed), they own the lifetime.
+/// Callers that use <see cref="TonlBufferWriter"/> should call <c>.ToArray()</c> on the
+/// <see cref="ReadOnlyMemory{T}"/> before constructing the <see cref="TonlElement"/> to disconnect
+/// from the underlying pool.
+/// </para>
+/// </remarks>
+public readonly struct TonlElement
+{
+    /// <summary>
+    /// Gets the pre-rendered TONL bytes held by this element.
+    /// </summary>
+    public ReadOnlyMemory<byte> Bytes { get; }
+
+    /// <summary>
+    /// Initializes a new <see cref="TonlElement"/> wrapping the given bytes.
+    /// </summary>
+    /// <param name="bytes">Pre-rendered TONL bytes. The caller retains lifetime ownership.</param>
+    public TonlElement(ReadOnlyMemory<byte> bytes) { Bytes = bytes; }
+
+    /// <summary>
+    /// Gets an empty <see cref="TonlElement"/> (default instance with no bytes).
+    /// </summary>
+    public static TonlElement Empty => default;
+
+    /// <summary>
+    /// Gets a value indicating whether this element contains no bytes.
+    /// </summary>
+    public bool IsEmpty => Bytes.IsEmpty;
+}

--- a/src/TONL.NET.Core/TonlWriter.cs
+++ b/src/TONL.NET.Core/TonlWriter.cs
@@ -308,6 +308,16 @@ public ref struct TonlWriter
     }
 
     /// <summary>
+    /// Writes an unsigned long key-value pair: key: 18446744073709551615
+    /// </summary>
+    public void WriteKeyUInt64(ReadOnlySpan<char> key, ulong value)
+    {
+        WriteKey(key);
+        WriteRaw(ColonSpace);
+        WriteUInt64(value);
+    }
+
+    /// <summary>
     /// Writes a double key-value pair: key: 3.14
     /// </summary>
     public void WriteKeyDouble(ReadOnlySpan<char> key, double value)
@@ -378,6 +388,23 @@ public ref struct TonlWriter
         else
         {
             WriteUtf8String(value.ToString(CultureInfo.InvariantCulture));
+        }
+    }
+
+    /// <summary>
+    /// Writes an unsigned long value.
+    /// ulong.MaxValue = 18446744073709551615 (20 digits).
+    /// </summary>
+    public void WriteUInt64(ulong value)
+    {
+        EnsureCapacity(20);
+        if (Utf8Formatter.TryFormat(value, _buffer.Slice(_buffered), out int written))
+        {
+            _buffered += written;
+        }
+        else
+        {
+            throw new InvalidOperationException("Failed to format ulong.");
         }
     }
 
@@ -687,6 +714,24 @@ public ref struct TonlWriter
         _buffered += bytesWritten;
     }
 
+    /// <summary>
+    /// Writes a pre-rendered TONL value fragment into the current writer position.
+    /// The caller is responsible for the fragment being syntactically valid TONL
+    /// at the current writer state. No validation, no quoting, no escaping is applied.
+    /// </summary>
+    public void WriteRawValue(scoped ReadOnlySpan<byte> value) => WriteRaw(value);
+
+    /// <summary>
+    /// Writes a key followed by a pre-rendered TONL value fragment.
+    /// The key is quoted per spec when required; the value bytes are emitted as-is.
+    /// </summary>
+    public void WriteKeyRawValue(ReadOnlySpan<char> key, scoped ReadOnlySpan<byte> rawValue)
+    {
+        WriteKey(key);
+        WriteRaw(ColonSpace);
+        WriteRaw(rawValue);
+    }
+
     private void WriteRaw(scoped ReadOnlySpan<byte> data)
     {
         EnsureCapacity(data.Length);
@@ -734,6 +779,11 @@ file static class Utf8Formatter
     }
 
     public static bool TryFormat(long value, Span<byte> destination, out int bytesWritten)
+    {
+        return System.Buffers.Text.Utf8Formatter.TryFormat(value, destination, out bytesWritten);
+    }
+
+    public static bool TryFormat(ulong value, Span<byte> destination, out int bytesWritten)
     {
         return System.Buffers.Text.Utf8Formatter.TryFormat(value, destination, out bytesWritten);
     }

--- a/src/TONL.NET.SourceGenerator/CodeGenerator.cs
+++ b/src/TONL.NET.SourceGenerator/CodeGenerator.cs
@@ -241,6 +241,7 @@ internal static class CodeGenerator
 
         return prop.Category switch
         {
+            PropertyCategory.TonlElement => "global::TONL.NET.TonlElement.Empty", // Cannot meaningfully deserialize pre-rendered bytes from dictionary
             PropertyCategory.Boolean => GetTypedConversion(dictAccess, "bool", prop.IsNullable, index),
             PropertyCategory.Integer => GetNumericConversion(dictAccess, baseType, prop.IsNullable, index),
             PropertyCategory.Float => GetNumericConversion(dictAccess, baseType, prop.IsNullable, index),
@@ -366,6 +367,15 @@ internal static class CodeGenerator
     private static void GeneratePropertyWriteForTopLevel(StringBuilder sb, PropertyInfo prop, string valuePrefix)
     {
         var access = $"{valuePrefix}.{prop.Name}";
+
+        // TonlElement: emit pre-rendered bytes directly — no key quoting of the value, no recursion.
+        if (prop.Category == PropertyCategory.TonlElement)
+        {
+            sb.AppendLine("            writer.WriteIndent(1);");
+            sb.AppendLine($"            writer.WriteKeyRawValue(\"{prop.Name}\", {access}.Bytes.Span);");
+            sb.AppendLine("            writer.WriteNewLine();");
+            return;
+        }
 
         // Handle collection and object properties specially - they need multi-line code blocks
         if (prop.Category == PropertyCategory.Collection)
@@ -515,6 +525,15 @@ internal static class CodeGenerator
     {
         var access = $"{valuePrefix}.{prop.Name}";
 
+        // TonlElement: emit pre-rendered bytes directly — no key quoting of the value, no recursion.
+        if (prop.Category == PropertyCategory.TonlElement)
+        {
+            sb.AppendLine("            writer.WriteIndent(2);");
+            sb.AppendLine($"            writer.WriteKeyRawValue(\"{prop.Name}\", {access}.Bytes.Span);");
+            sb.AppendLine("            writer.WriteNewLine();");
+            return;
+        }
+
         // Handle collection and object properties specially - they need multi-line code blocks
         if (prop.Category == PropertyCategory.Collection)
         {
@@ -559,12 +578,16 @@ internal static class CodeGenerator
         // For nested serialization, only handle primitives - complex types fall back to ToString
         switch (prop.Category)
         {
+            case PropertyCategory.TonlElement:
+                // Pre-rendered bytes — emit directly without quoting or escaping the value.
+                sb.AppendLine($"writer.WriteKeyRawValue(\"{prop.Name}\", {access}.Bytes.Span);");
+                break;
             case PropertyCategory.Boolean:
                 sb.AppendLine($"writer.WriteKeyBoolean(\"{prop.Name}\", {access});");
                 break;
             case PropertyCategory.Integer:
                 if (prop.TypeName.Contains("UInt64") || prop.TypeName.Contains("ulong"))
-                    sb.AppendLine($"writer.WriteKeyValue(\"{prop.Name}\", {access}.ToString());");
+                    sb.AppendLine($"writer.WriteKeyUInt64(\"{prop.Name}\", {access});");
                 else if (prop.TypeName.Contains("Int64") || prop.TypeName.Contains("long"))
                     sb.AppendLine($"writer.WriteKeyInt64(\"{prop.Name}\", {access});");
                 else if (prop.TypeName.Contains("UInt32") || prop.TypeName.Contains("uint"))
@@ -846,12 +869,16 @@ internal static class CodeGenerator
         // Write value without key for tabular format
         switch (prop.Category)
         {
+            case PropertyCategory.TonlElement:
+                // Pre-rendered bytes — emit directly without quoting or escaping.
+                sb.AppendLine($"            writer.WriteRawValue({access}.Bytes.Span);");
+                break;
             case PropertyCategory.Boolean:
                 sb.AppendLine($"            writer.WriteBoolean({valueAccess});");
                 break;
             case PropertyCategory.Integer:
                 if (prop.TypeName.Contains("UInt64") || prop.TypeName.Contains("ulong"))
-                    sb.AppendLine($"            writer.WriteStringValue({valueAccess}.ToString());");
+                    sb.AppendLine($"            writer.WriteUInt64({valueAccess});");
                 else if (prop.TypeName.Contains("Int64") || prop.TypeName.Contains("long"))
                     sb.AppendLine($"            writer.WriteInt64({valueAccess});");
                 else if (prop.TypeName.Contains("UInt32") || prop.TypeName.Contains("uint"))
@@ -1373,13 +1400,17 @@ internal static class CodeGenerator
     {
         switch (prop.Category)
         {
+            case PropertyCategory.TonlElement:
+                // Pre-rendered bytes — emit directly without quoting or escaping the value.
+                sb.AppendLine($"writer.WriteKeyRawValue(\"{prop.Name}\", {access}.Bytes.Span);");
+                break;
             case PropertyCategory.Boolean:
                 sb.AppendLine($"writer.WriteKeyBoolean(\"{prop.Name}\", {access});");
                 break;
             case PropertyCategory.Integer:
                 // Handle all integer types appropriately
                 if (prop.TypeName.Contains("UInt64") || prop.TypeName.Contains("ulong"))
-                    sb.AppendLine($"writer.WriteKeyValue(\"{prop.Name}\", {access}.ToString());"); // ulong as string to preserve full range
+                    sb.AppendLine($"writer.WriteKeyUInt64(\"{prop.Name}\", {access});");
                 else if (prop.TypeName.Contains("Int64") || prop.TypeName.Contains("long"))
                     sb.AppendLine($"writer.WriteKeyInt64(\"{prop.Name}\", {access});");
                 else if (prop.TypeName.Contains("UInt32") || prop.TypeName.Contains("uint"))

--- a/src/TONL.NET.SourceGenerator/TonlSourceGenerator.cs
+++ b/src/TONL.NET.SourceGenerator/TonlSourceGenerator.cs
@@ -223,6 +223,8 @@ public class TonlSourceGenerator : IIncrementalGenerator
             _ when displayName == "global::System.DateTimeOffset" => PropertyCategory.DateTime,
             _ when displayName == "global::System.Guid" => PropertyCategory.Guid,
             _ when displayName == "global::System.TimeSpan" => PropertyCategory.TimeSpan,
+            // TonlElement is a leaf — emit raw bytes directly, never recurse into its Bytes payload.
+            _ when displayName == "global::TONL.NET.TonlElement" => PropertyCategory.TonlElement,
             _ when type.TypeKind == TypeKind.Enum => PropertyCategory.Enum,
             _ when IsCollectionType(type) => PropertyCategory.Collection,
             _ when type.TypeKind == TypeKind.Class || type.TypeKind == TypeKind.Struct => PropertyCategory.Object,
@@ -1017,7 +1019,12 @@ internal enum PropertyCategory
     TimeSpan,
     Enum,
     Collection,
-    Object
+    Object,
+    /// <summary>
+    /// Represents a <see cref="TONL.NET.TonlElement"/> property — pre-rendered TONL bytes
+    /// that the source generator emits directly via WriteKeyRawValue without recursion.
+    /// </summary>
+    TonlElement
 }
 
 /// <summary>

--- a/tests/TONL.NET.AotTests/Program.cs
+++ b/tests/TONL.NET.AotTests/Program.cs
@@ -92,6 +92,12 @@ public enum Status
     Pending = 2
 }
 
+// v1.2.0: TonlElement holder — validates source-gen special-case under NativeAOT
+public record AotTonlElementHolder(TonlElement Rows, int RowCount);
+
+// v1.2.0: ulong record — validates WriteKeyUInt64 codegen under NativeAOT
+public record AotULongRecord(ulong MaxValue, string Label);
+
 // ============================================================
 // Context class with source generation
 // ============================================================
@@ -113,6 +119,9 @@ public enum Status
 [TonlSerializable(typeof(OrderRecord))]
 [TonlSerializable(typeof(EnumerableRecord))]
 [TonlSerializable(typeof(ConcurrentRecord))]
+// v1.2.0 types
+[TonlSerializable(typeof(AotTonlElementHolder))]
+[TonlSerializable(typeof(AotULongRecord))]
 public partial class AotTestContext : TonlSerializerContext { }
 
 // ============================================================
@@ -156,6 +165,10 @@ public class Program
             TestContextGetTypeInfo();
             TestContextSingleton();
             TestSerializeToBytes();
+
+            // v1.2.0 tests
+            TestTonlElementHolder();
+            TestULongRecord();
 
             // Print summary
             Console.WriteLine($"\n{'=',-50}");
@@ -441,6 +454,43 @@ public class Program
 
         // Should contain key
         Assert("Concurrent - contains ThreadSafeScores key", tonl.Contains("ThreadSafeScores"));
+    }
+
+    private static void TestTonlElementHolder()
+    {
+        // Build a TonlElement from known bytes (disconnected from any pool via ToArray)
+        var rawBytes = "x: 1\ny: 2\n"u8.ToArray();
+        var element = new TonlElement(rawBytes);
+        var record = new AotTonlElementHolder(element, 2);
+
+        var tonl = TonlSerializer.SerializeToString(record, AotTestContext.Default.AotTonlElementHolder);
+
+        Console.WriteLine("\n--- AotTonlElementHolder TONL Output ---");
+        Console.WriteLine(tonl);
+        Console.WriteLine("--- End Output ---\n");
+
+        // Raw bytes inlined — no recursive Bytes serialization
+        Assert("TonlElement - raw content x: 1 present", tonl.Contains("x: 1"));
+        Assert("TonlElement - raw content y: 2 present", tonl.Contains("y: 2"));
+        Assert("TonlElement - no Bytes: key (no recursion)", !tonl.Contains("Bytes:"));
+        Assert("TonlElement - no IsEmpty key (no recursion)", !tonl.Contains("IsEmpty:"));
+        Assert("TonlElement - RowCount present", tonl.Contains("RowCount: 2"));
+    }
+
+    private static void TestULongRecord()
+    {
+        var record = new AotULongRecord(ulong.MaxValue, "max");
+
+        var tonl = TonlSerializer.SerializeToString(record, AotTestContext.Default.AotULongRecord);
+
+        Console.WriteLine("\n--- AotULongRecord TONL Output ---");
+        Console.WriteLine(tonl);
+        Console.WriteLine("--- End Output ---\n");
+
+        // ulong.MaxValue must be a bare integer, not a quoted string
+        Assert("ULongRecord - bare integer 18446744073709551615", tonl.Contains("18446744073709551615"));
+        Assert("ULongRecord - not quoted string", !tonl.Contains("\"18446744073709551615\""));
+        Assert("ULongRecord - Label present", tonl.Contains("max"));
     }
 
     private static void Assert(string testName, bool condition)

--- a/tests/TONL.NET.Tests/SourceGeneratorTests.cs
+++ b/tests/TONL.NET.Tests/SourceGeneratorTests.cs
@@ -1593,3 +1593,112 @@ public class ConstraintListBlockFormatTests
         Assert.Contains("UserId", tonl);
     }
 }
+
+// =============================================================================
+// TonlElement source-generator special-case tests (v1.2.0)
+// =============================================================================
+
+/// <summary>
+/// Record with a TonlElement property used to embed pre-rendered TONL bytes.
+/// Registered via V120Context (not directly attributed to avoid hint-name collisions).
+/// </summary>
+public record TonlElementRecord(TonlElement Rows, int RowCount);
+
+/// <summary>
+/// Record with a ulong property to verify WriteKeyUInt64 codegen.
+/// Registered via V120Context.
+/// </summary>
+public record ULongRecord(ulong MaxValue, string Label);
+
+/// <summary>
+/// Context for registering v1.2.0 new-API types.
+/// </summary>
+[TonlSourceGenerationOptions]
+[TonlSerializable(typeof(TonlElementRecord))]
+[TonlSerializable(typeof(ULongRecord))]
+public partial class V120Context : TonlSerializerContext { }
+
+/// <summary>
+/// Tests verifying v1.2.0 source-generator additions: TonlElement and ulong.
+/// </summary>
+public class V120SourceGeneratorTests
+{
+    [Fact]
+    public void TonlElement_PropertySerializedAsRawBytes_NotRecursiveBytes()
+    {
+        // Arrange: raw TONL bytes that look like a block result set
+        var rawTonl = "x: 1\ny: 2\n"u8.ToArray();
+        var element = new TonlElement(rawTonl);
+        var record = new TonlElementRecord(element, 2);
+
+        // Act: use context-based serializer (source-gen path)
+        var tonl = TonlSerializer.SerializeToString(record, V120Context.Default.TonlElementRecord);
+
+        // Assert: raw bytes appear inline — no recursive "Bytes: { ... }" shape
+        Assert.Contains("x: 1", tonl);
+        Assert.Contains("y: 2", tonl);
+        Assert.DoesNotContain("Bytes:", tonl);
+        Assert.DoesNotContain("IsEmpty:", tonl);
+        Assert.Contains("RowCount: 2", tonl);
+    }
+
+    [Fact]
+    public void TonlElement_EmptyElement_DoesNotCrash()
+    {
+        var record = new TonlElementRecord(TonlElement.Empty, 0);
+        var tonl = TonlSerializer.SerializeToString(record, V120Context.Default.TonlElementRecord);
+
+        // Empty element emits nothing for the value bytes — key still present
+        Assert.Contains("Rows:", tonl);
+        Assert.Contains("RowCount: 0", tonl);
+    }
+
+    [Fact]
+    public void TonlElement_DirectSerializerSerializeToString_InlinesBytes()
+    {
+        var rawTonl = "count: 99\n"u8.ToArray();
+        var element = new TonlElement(rawTonl);
+        var record = new TonlElementRecord(element, 1);
+
+        // Also works via the directly-generated serializer class
+        var tonl = TonlElementRecordTonlSerializer.SerializeToString(record);
+
+        Assert.Contains("count: 99", tonl);
+        Assert.DoesNotContain("Bytes:", tonl);
+    }
+
+    [Fact]
+    public void ULongRecord_ValuesAboveLongMax_EmittedAsBareIntegers_NotQuotedStrings()
+    {
+        var record = new ULongRecord(ulong.MaxValue, "max");
+
+        var tonl = TonlSerializer.SerializeToString(record, V120Context.Default.ULongRecord);
+
+        // ulong.MaxValue = 18446744073709551615 — must be bare integer, not "18446744073709551615"
+        Assert.Contains("18446744073709551615", tonl);
+        Assert.DoesNotContain("\"18446744073709551615\"", tonl);
+    }
+
+    [Fact]
+    public void ULongRecord_Zero_EmittedAsBareInteger()
+    {
+        var record = new ULongRecord(0UL, "zero");
+
+        var tonl = ULongRecordTonlSerializer.SerializeToString(record);
+
+        Assert.Contains("MaxValue: 0", tonl);
+        Assert.DoesNotContain("\"0\"", tonl);
+    }
+
+    [Fact]
+    public void ULongRecord_LongMaxPlusOne_EmittedAsBareInteger()
+    {
+        var value = (ulong)long.MaxValue + 1UL;
+        var record = new ULongRecord(value, "boundary");
+
+        var tonl = ULongRecordTonlSerializer.SerializeToString(record);
+
+        Assert.Contains("9223372036854775808", tonl);
+        Assert.DoesNotContain("\"9223372036854775808\"", tonl);
+    }
+}

--- a/tests/TONL.NET.Tests/TonlWriterTests.cs
+++ b/tests/TONL.NET.Tests/TonlWriterTests.cs
@@ -322,4 +322,107 @@ public class TonlWriterTests
         var result = buffer.ToString();
         Assert.Equal("[2]{\"@id\",\"first-name\"}:", result);
     }
+
+    // -------------------------------------------------------------------------
+    // WriteRawValue / WriteKeyRawValue Tests
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public void WriteRawValue_EmitsExactBytes_WithNoQuotingOrEscaping()
+    {
+        using var buffer = new TonlBufferWriter();
+        var writer = new TonlWriter(buffer);
+
+        var raw = "42"u8;
+        writer.WriteRawValue(raw);
+        writer.Flush();
+
+        Assert.Equal("42", buffer.ToString());
+    }
+
+    [Fact]
+    public void WriteRawValue_MultilineFragment_EmittedAsIs()
+    {
+        using var buffer = new TonlBufferWriter();
+        var writer = new TonlWriter(buffer);
+
+        // A fragment that looks like a TONL nested block
+        var raw = "{\n  x: 1\n  y: 2\n}"u8;
+        writer.WriteRawValue(raw);
+        writer.Flush();
+
+        Assert.Equal("{\n  x: 1\n  y: 2\n}", buffer.ToString());
+    }
+
+    [Fact]
+    public void WriteKeyRawValue_EmitsKeyColonSpaceThenRawBytes()
+    {
+        using var buffer = new TonlBufferWriter();
+        var writer = new TonlWriter(buffer);
+
+        var raw = "hello world"u8;
+        writer.WriteKeyRawValue("rows", raw);
+        writer.Flush();
+
+        Assert.Equal("rows: hello world", buffer.ToString());
+    }
+
+    [Fact]
+    public void WriteKeyRawValue_QuotesKeyWhenRequired()
+    {
+        using var buffer = new TonlBufferWriter();
+        var writer = new TonlWriter(buffer);
+
+        var raw = "99"u8;
+        writer.WriteKeyRawValue("@special", raw);
+        writer.Flush();
+
+        Assert.Equal("\"@special\": 99", buffer.ToString());
+    }
+
+    // -------------------------------------------------------------------------
+    // WriteUInt64 / WriteKeyUInt64 Tests
+    // -------------------------------------------------------------------------
+
+    [Theory]
+    [InlineData(0UL, "0")]
+    [InlineData(long.MaxValue, "9223372036854775807")]
+    [InlineData((ulong)long.MaxValue + 1UL, "9223372036854775808")]
+    [InlineData(ulong.MaxValue, "18446744073709551615")]
+    public void WriteUInt64_EmitsBareInteger(ulong value, string expected)
+    {
+        using var buffer = new TonlBufferWriter();
+        var writer = new TonlWriter(buffer);
+
+        writer.WriteUInt64(value);
+        writer.Flush();
+
+        Assert.Equal(expected, buffer.ToString());
+    }
+
+    [Theory]
+    [InlineData(0UL, "count: 0")]
+    [InlineData(ulong.MaxValue, "count: 18446744073709551615")]
+    public void WriteKeyUInt64_EmitsKeyColonSpaceThenBareInteger(ulong value, string expected)
+    {
+        using var buffer = new TonlBufferWriter();
+        var writer = new TonlWriter(buffer);
+
+        writer.WriteKeyUInt64("count", value);
+        writer.Flush();
+
+        Assert.Equal(expected, buffer.ToString());
+    }
+
+    [Fact]
+    public void WriteKeyUInt64_QuotesKeyWhenRequired()
+    {
+        using var buffer = new TonlBufferWriter();
+        var writer = new TonlWriter(buffer);
+
+        writer.WriteKeyUInt64("@count", 42UL);
+        writer.Flush();
+
+        Assert.Equal("\"@count\": 42", buffer.ToString());
+    }
 }


### PR DESCRIPTION
Closes #23

## Summary

Three additive API surfaces unblocking downstream consumers that need to embed dynamic-schema payloads inside source-gen-serialized envelopes (specifically srs-platform Oracle MCP service — see Spire-Recovery-Solutions/srs-platform#1667).

## Changes

- `TonlElement` readonly struct wrapping pre-rendered TONL bytes
- Public `WriteRawValue` / `WriteKeyRawValue` on TonlWriter
- `WriteUInt64` / `WriteKeyUInt64` — closes the ulong API gap (source gen previously fell back to ToString)
- Source generator special-cases `TonlElement` (no recursion) and emits `WriteKeyUInt64` for ulong properties

## Tests

- New xUnit coverage in `TonlWriterTests.cs`, `SourceGeneratorTests.cs` (+17 tests, 377 total)
- New AOT test records in `tests/TONL.NET.AotTests/Program.cs` validating TonlElement source-gen under NativeAOT (+7 tests, 58 total)

## Spec compliance

All additions are .NET API-level — no wire-format changes. The new upstream spec commit (`tonl-dev/tonl@e8f5337`) confirms tabular array form is correct for primitive-only object arrays, which is the consumer use case driving this work.